### PR TITLE
feat(humanizer): adds severity humanizer function

### DIFF
--- a/src/humanizer.ts
+++ b/src/humanizer.ts
@@ -1,4 +1,4 @@
-import { BaseMetric, BaseMetricValue, Severity } from './models';
+import { BaseMetric, BaseMetricValue } from './models';
 
 export const humanizeBaseMetric = (baseMetric: BaseMetric): string => {
   switch (baseMetric) {

--- a/src/humanizer.ts
+++ b/src/humanizer.ts
@@ -55,4 +55,12 @@ export const humanizeBaseMetricValue = (
  * @param score
  */
 export const toSeverity = (score: number): Severity =>
-  score <= 0 ? 'None' : score <= 3.9 ? 'Low' : score <= 6.9 ? 'Medium' : score <= 8.9 ? 'High' : 'Critical';
+  score <= 0
+    ? 'None'
+    : score <= 3.9
+    ? 'Low'
+    : score <= 6.9
+    ? 'Medium'
+    : score <= 8.9
+    ? 'High'
+    : 'Critical';

--- a/src/humanizer.ts
+++ b/src/humanizer.ts
@@ -1,4 +1,4 @@
-import { BaseMetric, BaseMetricValue } from './models';
+import { BaseMetric, BaseMetricValue, Severity } from './models';
 
 export const humanizeBaseMetric = (baseMetric: BaseMetric): string => {
   switch (baseMetric) {
@@ -49,3 +49,10 @@ export const humanizeBaseMetricValue = (
       return 'Unknown';
   }
 };
+
+/**
+ * Stringify an score into a severity string ('None' | 'Low' | 'Medium' | 'High' | 'Critical')
+ * @param score
+ */
+export const toSeverity = (score: number): Severity =>
+  score <= 0 ? 'None' : score <= 3.9 ? 'Low' : score <= 6.9 ? 'Medium' : score <= 8.9 ? 'High' : 'Critical';

--- a/src/humanizer.ts
+++ b/src/humanizer.ts
@@ -51,10 +51,10 @@ export const humanizeBaseMetricValue = (
 };
 
 /**
- * Stringify an score into a severity string ('None' | 'Low' | 'Medium' | 'High' | 'Critical')
+ * Stringify a score into a qualitative severity rating string
  * @param score
  */
-export const toSeverity = (score: number): Severity =>
+export const humanizeScore = (score: number): string =>
   score <= 0
     ? 'None'
     : score <= 3.9

--- a/src/models.ts
+++ b/src/models.ts
@@ -9,8 +9,6 @@ export enum BaseMetric {
   AVAILABILITY = 'A'
 }
 
-export type Severity = 'None' | 'Low' | 'Medium' | 'High' | 'Critical';
-
 export const baseMetrics: ReadonlyArray<BaseMetric> = [
   BaseMetric.ATTACK_VECTOR,
   BaseMetric.ATTACK_COMPLEXITY,

--- a/src/models.ts
+++ b/src/models.ts
@@ -9,6 +9,8 @@ export enum BaseMetric {
   AVAILABILITY = 'A'
 }
 
+export type Severity = 'None' | 'Low' | 'Medium' | 'High' | 'Critical';
+
 export const baseMetrics: ReadonlyArray<BaseMetric> = [
   BaseMetric.ATTACK_VECTOR,
   BaseMetric.ATTACK_COMPLEXITY,

--- a/tests/humanizer.spec.ts
+++ b/tests/humanizer.spec.ts
@@ -3,7 +3,7 @@ import {
   BaseMetricValue,
   humanizeBaseMetric,
   humanizeBaseMetricValue,
-  toSeverity
+  humanizeScore
 } from '../src';
 import { expect } from 'chai';
 
@@ -53,23 +53,32 @@ describe('humanizer', () => {
     );
     expect(result).to.equal('Unknown');
   });
-});
 
-describe('risk levels', () => {
-  it('Should give None risk level when score is below 0', () => {
-    expect(toSeverity(0)).to.equal('None');
-    expect(toSeverity(-7)).to.equal('None');
+  it('should humanize score as "None" for zero value', () => {
+    expect(humanizeScore(0)).to.equal('None');
   });
-  it('Should give Low risk level when score is below 3', () => {
-    expect(toSeverity(3)).to.equal('Low');
-    expect(toSeverity(1.2654)).to.equal('Low');
+
+  it('should humanize score as "Low" for values from interval [0.1, 3.9]', () => {
+    expect(humanizeScore(0.1)).to.equal('Low');
+    expect(humanizeScore(1.2)).to.equal('Low');
+    expect(humanizeScore(3.9)).to.equal('Low');
   });
-  it('Should give Medium risk level when score is below 6', () => {
-    expect(toSeverity(6)).to.equal('Medium');
-    expect(toSeverity(4.2654)).to.equal('Medium');
+
+  it('should humanize score as "Medium" for values from interval [4.0, 6.9]', () => {
+    expect(humanizeScore(4.0)).to.equal('Medium');
+    expect(humanizeScore(4.2)).to.equal('Medium');
+    expect(humanizeScore(6.9)).to.equal('Medium');
   });
-  it('Should give High risk level when score is below 8.5', () => {
-    expect(toSeverity(8.5)).to.equal('High');
-    expect(toSeverity(7.2654)).to.equal('High');
+
+  it('should humanize score as "High" for values from interval [7.0, 8.9]', () => {
+    expect(humanizeScore(7.0)).to.equal('High');
+    expect(humanizeScore(7.5)).to.equal('High');
+    expect(humanizeScore(8.9)).to.equal('High');
+  });
+
+  it('should humanize score as "Critical" for values from interval [9.0, 10.0]', () => {
+    expect(humanizeScore(9.0)).to.equal('Critical');
+    expect(humanizeScore(9.5)).to.equal('Critical');
+    expect(humanizeScore(10.0)).to.equal('Critical');
   });
 });

--- a/tests/humanizer.spec.ts
+++ b/tests/humanizer.spec.ts
@@ -2,7 +2,8 @@ import {
   BaseMetric,
   BaseMetricValue,
   humanizeBaseMetric,
-  humanizeBaseMetricValue
+  humanizeBaseMetricValue,
+  toSeverity
 } from '../src';
 import { expect } from 'chai';
 
@@ -51,5 +52,24 @@ describe('humanizer', () => {
       ('X' as unknown) as BaseMetric
     );
     expect(result).to.equal('Unknown');
+  });
+});
+
+describe('risk levels', () => {
+  it('Should give None risk level when score is below 0', () => {
+    expect(toSeverity(0)).to.equal('None');
+    expect(toSeverity(-7)).to.equal('None');
+  });
+  it('Should give Low risk level when score is below 3', () => {
+    expect(toSeverity(3)).to.equal('Low');
+    expect(toSeverity(1.2654)).to.equal('Low');
+  });
+  it('Should give Medium risk level when score is below 6', () => {
+    expect(toSeverity(6)).to.equal('Medium');
+    expect(toSeverity(4.2654)).to.equal('Medium');
+  });
+  it('Should give High risk level when score is below 8.5', () => {
+    expect(toSeverity(8.5)).to.equal('High');
+    expect(toSeverity(7.2654)).to.equal('High');
   });
 });


### PR DESCRIPTION
Adds a function which returns a term according to a given severity score.
The term in question is the same as those given here for example: https://www.first.org/cvss/calculator/3.1